### PR TITLE
Include samba-common-tools into spec file

### DIFF
--- a/ipa-gpo-install.spec
+++ b/ipa-gpo-install.spec
@@ -13,6 +13,7 @@ BuildRequires: gettext-tools
 
 Requires: freeipa-server
 Requires: freeipa-server-trust-ad
+Requires: samba-common-tools
 Source0: %name-%version.tar
 
 %description


### PR DESCRIPTION
The `/usr/bin/net` command is a part of `samba-common-tools` package. This PR adds this package to `Requires:` section of the spec file.